### PR TITLE
feat: add component-store-with-entity-adapter option to the main function

### DIFF
--- a/src/ng-ag-grid-schematics/files/state/component-store-with-entity-adapter/__name@dasherize__.component.html
+++ b/src/ng-ag-grid-schematics/files/state/component-store-with-entity-adapter/__name@dasherize__.component.html
@@ -1,0 +1,11 @@
+<div class="grid-container">
+  <ag-grid-angular
+    (cellValueChanged)="onCellValueChanged($event.data)"
+    (gridReady)="onGridReady($event.api, $event.columnApi)"
+    [columnDefs]="columnDefs$ | async"
+    [rowData]="rowsList$ | async"
+    class="ag-theme-alpine"
+    style="width: 700px; height: 500px"></ag-grid-angular>
+</div>
+<hr />
+{{ rowsList$ | async | json }}

--- a/src/ng-ag-grid-schematics/files/state/component-store-with-entity-adapter/__name@dasherize__.component.ts
+++ b/src/ng-ag-grid-schematics/files/state/component-store-with-entity-adapter/__name@dasherize__.component.ts
@@ -1,0 +1,48 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  inject,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ColumnApi, GridApi } from 'ag-grid-enterprise';
+import { AgGridModule } from 'ag-grid-angular';
+import { <%= classify(name) %>Store } from './<%= dasherize(name) %>.store';
+import { <%= classify(name) %>Service } from './<%= dasherize(name) %>.service';
+import { map } from 'rxjs';
+import { RowData } from './<%= dasherize(name) %>.model';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [CommonModule, AgGridModule],
+  providers: [<%= classify(name) %>Store, <%= classify(name) %>Service],
+  templateUrl: './<%= dasherize(name) %>.component.html',
+  styleUrls: ['./<%= dasherize(name) %>.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class <%= classify(name) %>Component implements OnInit {
+  #gridApi!: GridApi;
+  #<%= camelize(name) %>Store = inject(<%= classify(name) %>Store);
+
+  protected readonly state$ = this.#<%= camelize(name) %>Store.state$;
+  protected readonly rowsList$ = this.#<%= camelize(name) %>Store.rowsList$;
+  protected readonly rowsDictionary$ = this.#<%= camelize(name) %>Store.rowsDictionary$;
+  protected readonly columnDefs$ = this.#<%= camelize(name) %>Store.state$.pipe(
+    map((d) => d.columnDefs)
+  );
+
+  ngOnInit(): void {
+    this.#<%= camelize(name) %>Store.load();
+  }
+
+  protected onCellValueChanged(params: RowData): void {
+    this.#<%= camelize(name) %>Store.update(params);
+  }
+
+  protected onGridReady(...params: [api: GridApi, columnApi: ColumnApi]): void {
+    const [api, columnApi] = params;
+    this.#gridApi = api;
+    columnApi.autoSizeAllColumns();
+  }
+}

--- a/src/ng-ag-grid-schematics/files/state/component-store-with-entity-adapter/__name@dasherize__.model.ts
+++ b/src/ng-ag-grid-schematics/files/state/component-store-with-entity-adapter/__name@dasherize__.model.ts
@@ -1,0 +1,15 @@
+import { ColDef } from 'ag-grid-enterprise';
+
+export type Status = 'INIT' | 'LOADING' | 'LOADED';
+
+export type RowData = {
+  id: string;
+  [key: string]: unknown;
+};
+
+export type <%= classify(name) %>State<T> = {
+  data: T
+  columnDefs: ColDef[];
+  status: Status;
+  error: unknown;
+};

--- a/src/ng-ag-grid-schematics/files/state/component-store-with-entity-adapter/__name@dasherize__.service.ts
+++ b/src/ng-ag-grid-schematics/files/state/component-store-with-entity-adapter/__name@dasherize__.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+import { rowData } from './mock';
+import { Observable, of } from 'rxjs';
+import { RowData } from './<%= dasherize(name) %>.model';
+
+@Injectable()
+export class <%= classify(name) %>Service {
+  #rowData = [...rowData];
+
+  public findMany(): Observable<RowData[]> {
+    return of(this.#rowData);
+  }
+
+  public findOneById(id: string): Observable<RowData | undefined> {
+    return of(this.#rowData.find((d) => d.id === id));
+  }
+
+  public updateMany(data: RowData[]): void {
+    this.#rowData = this.#rowData.map((r: any) => ({
+      ...r,
+      ...(data.find((d) => d.id === r.id) || {}),
+    }));
+  }
+
+  public updateOne(data: RowData): void {
+    const index = this.#rowData.findIndex((item) => item.id === data.id);
+
+    if (index === -1) throw new Error(`Item ${data.id} not found.`);
+
+    this.#rowData[index] = { ...this.#rowData[index], ...data };
+  }
+
+  public removeMany(ids: string[]): void {
+    this.#rowData = this.#rowData.filter((d: any) => !ids.includes(d.id));
+  }
+
+  public removeOne(idToRemove: string): void {
+    this.#rowData = this.#rowData.filter((d: any) => d.id !== idToRemove);
+  }
+}

--- a/src/ng-ag-grid-schematics/files/state/component-store-with-entity-adapter/__name@dasherize__.store.ts
+++ b/src/ng-ag-grid-schematics/files/state/component-store-with-entity-adapter/__name@dasherize__.store.ts
@@ -1,0 +1,116 @@
+import { Inject, Injectable, InjectionToken, inject } from '@angular/core';
+
+import { ComponentStore, tapResponse } from '@ngrx/component-store';
+import { columnDefs } from './mock';
+import { map, of, pipe, switchMap, tap, withLatestFrom } from 'rxjs';
+import { <%= classify(name) %>Service } from './<%= dasherize(name) %>.service';
+import { <%= classify(name) %>State, RowData } from './<%= dasherize(name) %>.model';
+import { EntityAdapter, EntityState, createEntityAdapter } from '@ngrx/entity';
+
+const ADAPTER = new InjectionToken('Entity Adapter', {
+  factory: () => createEntityAdapter<RowData>({ selectId: d => d.id })
+});
+
+@Injectable()
+export class <%= classify(name) %>Store extends ComponentStore<<%= classify(name) %>State<EntityState<RowData>>> {
+  #<%= camelize(name) %>Service = inject(<%= classify(name) %>Service);
+
+  constructor(
+    @Inject(ADAPTER) private readonly adapter: EntityAdapter<RowData>
+  ) {
+    super({
+      data: adapter.getInitialState(),
+      columnDefs: columnDefs,
+      status: 'INIT',
+      error: ''
+    });
+  }
+
+  public readonly rowsList$ = this.select(d => Object.values(d.data.entities));
+  public readonly rowsDictionary$ = this.select(d => d.data.entities);
+
+  public readonly load = this.effect<void>(
+    pipe(
+      withLatestFrom(this.select(s => s.data)),
+      tap(() => this.patchState({ status: 'LOADING' })),
+      switchMap(([, data]) =>
+        this.#<%= camelize(name) %>Service.findMany().pipe(
+          map(rows => ({
+            rows,
+            data
+          }))
+        )
+      ),
+      tapResponse(
+        ({ rows, data }) =>
+          this.patchState({
+            data: this.adapter.setAll(rows, data),
+            status: 'LOADED'
+          }),
+        error => this.patchState({ error, status: 'LOADED' })
+      )
+    )
+  );
+
+  public readonly add = this.effect<RowData>(params$ => {
+    return params$.pipe(
+      withLatestFrom(this.select(s => s.data)),
+      tap(() => this.patchState({ status: 'LOADING' })),
+      switchMap(([row, data]) => {
+        this.#<%= camelize(name) %>Service.updateOne(row);
+
+        return of({ row, data });
+      }),
+      tapResponse(
+        ({ row, data }) =>
+          this.patchState({
+            data: this.adapter.addOne(row, data),
+            status: 'LOADED'
+          }),
+        error => this.patchState({ error, status: 'LOADED' })
+      )
+    );
+  });
+
+  public readonly update = this.effect<RowData>(params$ => {
+    return params$.pipe(
+      withLatestFrom(this.select(s => s.data)),
+      tap(() => this.patchState({ status: 'LOADING' })),
+      switchMap(([row, data]) => {
+        this.#<%= camelize(name) %>Service.updateOne(row);
+
+        return of({ row, data });
+      }),
+      tapResponse(
+        ({ row, data }) => {
+          const { id, ...d } = row;
+          return this.patchState({
+            data: this.adapter.updateOne({ id, changes: d }, data),
+            status: 'LOADED'
+          });
+        },
+        error => this.patchState({ error, status: 'LOADED' })
+      )
+    );
+  });
+
+  public readonly remove = this.effect<string>(params$ => {
+    return params$.pipe(
+      withLatestFrom(this.select(s => s.data)),
+      tap(() => this.patchState({ status: 'LOADING' })),
+      switchMap(([id, data]) => {
+        this.#<%= camelize(name) %>Service.removeOne(id);
+
+        return of({ id, data });
+      }),
+      tapResponse(
+        ({ id, data }) =>
+          this.patchState({
+            data: this.adapter.removeOne(id, data),
+            status: 'LOADED'
+          }),
+        error => this.patchState({ error, status: 'LOADED' })
+      )
+    );
+  });
+}

--- a/src/ng-ag-grid-schematics/files/state/component-store-with-entity-adapter/mock.ts
+++ b/src/ng-ag-grid-schematics/files/state/component-store-with-entity-adapter/mock.ts
@@ -1,0 +1,130 @@
+import { ColDef } from 'ag-grid-community';
+
+export const rowData = [
+  {
+    id: '8a35e7c7-d52f-4a8d-af5c-06dbf2d891f1',
+    make: 'Toyota',
+    model: 'Celica',
+    price: 35000,
+  },
+  {
+    id: 'fd34bcde-5678-9012-3456-7890abcdef12',
+    make: 'Toyota',
+    model: 'Corolla',
+    price: 25000,
+  },
+  {
+    id: 'ab12cdef-3456-7890-1234-5678abcdef90',
+    make: 'Ford',
+    model: 'Mustang',
+    price: 45000,
+  },
+  {
+    id: '6789abcd-1234-5678-90ab-cdef12345678',
+    make: 'Honda',
+    model: 'Civic',
+    price: 20000,
+  },
+  {
+    id: '5432efgh-7890-1234-5678-90abcdef1234',
+    make: 'Chevrolet',
+    model: 'Camaro',
+    price: 40000,
+  },
+  {
+    id: 'bcdef123-4567-8901-2345-6789abcdef01',
+    make: 'BMW',
+    model: 'X5',
+    price: 60000,
+  },
+  {
+    id: '9012abcd-3456-7890-1234-5678abcdef90',
+    make: 'Mercedes-Benz',
+    model: 'E-Class',
+    price: 55000,
+  },
+  {
+    id: 'defg5678-90ab-cdef-1234-567890abcdef',
+    make: 'Audi',
+    model: 'A4',
+    price: 48000,
+  },
+  {
+    id: '56789012-3456-7890-abcd-ef1234567890',
+    make: 'Volkswagen',
+    model: 'Golf',
+    price: 30000,
+  },
+  {
+    id: 'abcd1234-5678-90ef-1234-567890abcdef',
+    make: 'Nissan',
+    model: 'Altima',
+    price: 28000,
+  },
+  {
+    id: '1234efgh-5678-90ab-cdef-1234567890ab',
+    make: 'Hyundai',
+    model: 'Elantra',
+    price: 22000,
+  },
+  {
+    id: 'efgh5678-90ab-cdef-1234-567890abcd12',
+    make: 'Kia',
+    model: 'Sorento',
+    price: 32000,
+  },
+  {
+    id: '23456789-0abc-def1-2345-67890abcdef1',
+    make: 'Mazda',
+    model: 'CX-5',
+    price: 35000,
+  },
+  {
+    id: '78901234-56ab-cdef-1234-567890abcdef',
+    make: 'Subaru',
+    model: 'Forester',
+    price: 32000,
+  },
+  {
+    id: '34567890-abcd-ef12-3456-7890abcdef12',
+    make: 'Jeep',
+    model: 'Wrangler',
+    price: 40000,
+  },
+  {
+    id: '9012abcd-ef12-3456-7890-abcdef123456',
+    make: 'GMC',
+    model: 'Sierra',
+    price: 45000,
+  },
+  {
+    id: 'def12345-6789-0abc-def1-234567890abc',
+    make: 'Ram',
+    model: '1500',
+    price: 50000,
+  },
+  {
+    id: '23456789-0abc-def1-2345-67890abcdef12',
+    make: 'Chevrolet',
+    model: 'Silverado',
+    price: 48000,
+  },
+  {
+    id: '34567890-abcd-ef12-3456-7890abcdef123',
+    make: 'Ford',
+    model: 'F-150',
+    price: 52000,
+  },
+  {
+    id: '9012abcd-ef12-3456-7890-abcdef123456',
+    make: 'Dodge',
+    model: 'Charger',
+    price: 38000,
+  },
+];
+
+export const columnDefs: ColDef[] = [
+  { headerName: 'Make', field: 'make' },
+  { headerName: 'Model', field: 'model' },
+  { headerName: 'Price', field: 'price', editable: true },
+];

--- a/src/ng-ag-grid-schematics/tests/index_spec.ts
+++ b/src/ng-ag-grid-schematics/tests/index_spec.ts
@@ -66,4 +66,33 @@ describe('ng-ag-grid-schematics', () => {
       ]);
     });
   });
+
+  describe('component-store-with-entity-adapter', () => {
+    it('should generate the expected files and configuration for a grid component', async () => {
+      const runner = new SchematicTestRunner('schematics', collectionPath);
+      const tree = await runner.runSchematic(
+        'ng-ag-grid-schematics',
+        {
+          name: 'grid',
+          path: '',
+          project: 'test-project',
+          style: 'scss',
+          state: 'component-store-with-entity-adapter'
+        },
+        testTree
+      );
+
+      expect(tree.files).toEqual([
+        '/angular.json',
+        '/package.json',
+        '/src/app/grid/mock.ts',
+        '/src/app/grid/grid.component.html',
+        '/src/app/grid/grid.component.ts',
+        '/src/app/grid/grid.model.ts',
+        '/src/app/grid/grid.service.ts',
+        '/src/app/grid/grid.store.ts',
+        '/src/app/grid/grid.component.scss'
+      ]);
+    });
+  });
 });

--- a/src/ng-ag-grid-schematics/tools/shared/add-npm-dependencies.ts
+++ b/src/ng-ag-grid-schematics/tools/shared/add-npm-dependencies.ts
@@ -15,9 +15,17 @@ export function addNpmDependencies(state: string): Rule {
     if (!packageJson.dependencies['ag-grid-enterprise'])
       packageJson.dependencies['ag-grid-enterprise'] = '*';
 
-    if (state === 'component-store') {
+    if (
+      state === 'component-store' ||
+      state === 'component-store-with-entity-adapter'
+    ) {
       if (!packageJson.dependencies['@ngrx/component-store'])
         packageJson.dependencies['@ngrx/component-store'] = '*';
+    }
+
+    if (state === 'component-store-with-entity-adapter') {
+      if (!packageJson.dependencies['@ngrx/entity'])
+        packageJson.dependencies['@ngrx/entity'] = '*';
     }
 
     tree.overwrite('package.json', JSON.stringify(packageJson, null, 2));


### PR DESCRIPTION
This commit introduces the add component-store
with entity adapter  option to the main function.
It includes the logic for enabling
component-Store integration within the main function, ensuring seamless interaction with no-store and
component-store features.

Additionally, relevant tests have been updated to
cover the new functionality.

#35